### PR TITLE
[#9] Rename the `$service` argument to `$vendor` for the `ClientInterface` service definition

### DIFF
--- a/src/PdfPackBundle.php
+++ b/src/PdfPackBundle.php
@@ -88,7 +88,7 @@ class PdfPackBundle extends AbstractBundle
                 // Clients
                 ->set(ClientInterface::class)
                     ->factory([service(ClientFactory::class), 'create'])
-                    ->arg('$service', $config['client'])
+                    ->arg('$vendor', $config['client'])
                 ->set(MockClient::class)
                     ->tag('onetomany.pdfpack.client', ['vendor' => 'mock'])
                 ->set(PopplerClient::class)


### PR DESCRIPTION
**Issues**
- #9